### PR TITLE
replace pipe with temp files and escape control chars manually

### DIFF
--- a/scripts/metadata-canonize.sh
+++ b/scripts/metadata-canonize.sh
@@ -22,10 +22,21 @@ if [ ! -f "$input_file" ]; then
     exit 1
 fi
 
+# Stage cardano-signer output through a temp file rather than a pipe, because large canonized outputs can exceed the 64 KB pipe buffer".
+TMP_RAW=$(mktemp /tmp/canonize_raw.XXXXXX.json)
+TMP_ESCAPED=$(mktemp /tmp/canonize_escaped.XXXXXX.json)
+trap 'rm -f "$TMP_RAW" "$TMP_ESCAPED"' EXIT
 
-# hash of the input file using cardano-cli
-# cardano-signer's --json-extended can emit unescaped control chars (e.g. raw newlines in body.abstract), which jq rejects. Escape them.
-hash=$(cardano-signer canonize --data-file $input_file --cip100 --json-extended --out-file /dev/stdout | perl -pe 's/([\x00-\x1f])/sprintf("\\u%04x",ord($1))/ge' | jq -r '.canonizedHash')
+cardano-signer canonize \
+  --data-file "$input_file" \
+  --cip100 \
+  --json-extended \
+  --out-file "$TMP_RAW"
+
+# cardano-signer's --json-extended can emit unescaped control chars (e.g. raw newlines in body.abstract), which jq rejects. Escape them in place.
+perl -pe 's/([\x00-\x1f])/sprintf("\\u%04x",ord($1))/ge' "$TMP_RAW" > "$TMP_ESCAPED"
+
+hash=$(jq -r '.canonizedHash' "$TMP_ESCAPED")
 
 # Output the result
 echo "For anchor file: $input_file"


### PR DESCRIPTION
instead of piping cardano-signer's output to jq, which breaks if control chars like literal tab-chars \t are used in the rationale, we   run it through a regex to escape the chars and clean up the canonized output before jq. 

the temp files also have the advantage that they arent subject to the 64 KB pipe buffer limit.

## List of changes

- Add / Fix / Change / Remove
